### PR TITLE
sort RangeTable

### DIFF
--- a/data/parse_range_table.go
+++ b/data/parse_range_table.go
@@ -46,6 +46,9 @@ func ParseRangeTable(property Property, data []byte) *unicode.RangeTable {
 		}
 	}
 
+	slices.SortFunc(r16s, func(a, b unicode.Range16) int { return int(a.Lo) - int(b.Lo) })
+	slices.SortFunc(r32s, func(a, b unicode.Range32) int { return int(a.Lo) - int(b.Lo) })
+
 	latinOffset := 0
 	for _, r16 := range r16s {
 		if r16.Hi <= unicode.MaxLatin1 {

--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,5 @@ module github.com/dmolesUC/emoji
 require (
 	github.com/kr/pretty v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 )

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,5 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
+golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=


### PR DESCRIPTION
without this `unicode.Is()` doesn't work as it performs binary search.